### PR TITLE
Allow the TestRunner project file to be resolved when using "rojo sourcemap"

### DIFF
--- a/modules/TestRunner/default.project.json
+++ b/modules/TestRunner/default.project.json
@@ -1,6 +1,7 @@
 {
     "name": "test-runner",
     "tree": {
+        "$className": "DataModel",
         "Src": {
             "$path": "src"
         }


### PR DESCRIPTION
As of right now without this clarification, the source map won't build.
![Screenshot_2](https://github.com/jsdotlua/react-lua/assets/53796817/94072564-84c4-4363-9da4-2e75fe771965)
